### PR TITLE
Bug Fix: Replace deprecated/missing dependency

### DIFF
--- a/installer/postinstall.sh
+++ b/installer/postinstall.sh
@@ -29,7 +29,8 @@ echo
 cd ..
 
 Installer_info "Rebuild MagicMirror..."
-MagicMirror-rebuild 2>/dev/null || {
+# Get the version of electron found in the main magic mirror package.json
+electron-rebuild --version $(grep -Po '"electron": "\^\K[^"]+' ../../package.json) 2>/dev/null || {
   Installer_error "Rebuild Failed"
   exit 255
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "license": "MIT",
   "dependencies": {
     "@electron/rebuild": "^3.6.0",
-    "speedtest-net": "^2.2.0",
     "check-node-version": "^4.2.1",
     "glob": "^9.2.1",
-    "minify": "^9.2.0"
+    "minify": "^9.2.0",
+    "speedtest-net": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "bugsounet",
   "license": "MIT",
   "dependencies": {
-    "electron-rebuild": "^3.6.0",
+    "@electron/rebuild": "^3.6.0",
     "speedtest-net": "^2.2.0",
     "check-node-version": "^4.2.1",
     "glob": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MMM-SpeedTest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "SpeedTest Magic Mirror.",
   "main": "MMM-SpeedTest.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "author": "bugsounet",
   "license": "MIT",
   "dependencies": {
-    "magicmirror-rebuild": "^1.0.3",
+    "electron-rebuild": "^3.6.0",
     "speedtest-net": "^2.2.0",
     "check-node-version": "^4.2.1",
     "glob": "^9.2.1",


### PR DESCRIPTION
I came across the same error detailed in this issue:
https://github.com/Antgr36/MMM-SpeedTest/issues/10

The error describes a package/dependency that no longer exists and was forked from the [electron/rebuild](https://github.com/electron/rebuild) project. This change moves back to the original `electron-rebuild` tool, and updates the command to ensure the magicmirror is rebuilt. This command requires passing an electron version, which was derived with a grep command isolating the dependency in the main magicmirror package.json

Using these changes I was able to get the module running on my raspberry pi 4

<details>
  <summary>Manual testing logs...</summary>

  ```bash
  $ npm install
  npm WARN deprecated osenv@0.1.5: This package is no longer supported.
  npm WARN deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
  npm WARN deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
  npm WARN deprecated npmlog@6.0.2: This package is no longer supported.
  npm WARN deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
  npm WARN deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
  npm WARN deprecated npmlog@4.1.2: This package is no longer supported.
  npm WARN deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
  npm WARN deprecated are-we-there-yet@3.0.1: This package is no longer supported.
  npm WARN deprecated are-we-there-yet@1.1.7: This package is no longer supported.
  npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
  npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
  npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
  npm WARN deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
  npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
  npm WARN deprecated gauge@4.0.4: This package is no longer supported.
  npm WARN deprecated gauge@2.7.4: This package is no longer supported.
  npm WARN deprecated node-pre-gyp@0.11.0: Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future

  > MMM-SpeedTest@1.1.1 preinstall
  > installer/preinstall.sh


  Welcome to MMM-SpeedTest v1.1.1

  No root checking...
  Checking MMM-SpeedTest: pi/pi
  Checking MagicMirror: pi/pi

  Checking OS...
  OS Detected: linux-gnu (debian 12 aarch64)

  Checking all dependencies...
  All Dependencies needed are installed !


  > MMM-SpeedTest@1.1.1 postinstall
  > installer/postinstall.sh

  Minify Main code
  Found: 5 files to minify

  Process File: ../MMM-SpeedTest.js
  Process File: ../node_helper.js
  Process File: ../components/raphael-2.1.4.min.js
  Process File: ../components/justgage.js
  Process File: ../components/loadLibraries.js
  Done

  Rebuild MagicMirror...
  Done

  MMM-SpeedTest is now installed !

  added 399 packages, and audited 400 packages in 4m

  41 packages are looking for funding
    run `npm fund` for details

  9 vulnerabilities (6 moderate, 3 high)

  To address issues that do not require attention, run:
    npm audit fix

  To address all issues (including breaking changes), run:
    npm audit fix --force

  Run `npm audit` for details.
  ```
  I wasn't able to successfully update any other dependencies... will follow up.

</details>